### PR TITLE
Fix: #22 Server name and channel name length limit not set 

### DIFF
--- a/components/chat/chat-header.jsx
+++ b/components/chat/chat-header.jsx
@@ -17,7 +17,7 @@ export const ChatHeader = ({ serverId, name, type, imageUrl }) => {
       {type === "conversation" && (
         <UserAvatar src={imageUrl} className="h-8 w-8 md:h-8 md:w-8 mr-2" />
       )}
-      <p className="font-semibold text-md text-black dark:dark:bg-gradient-to-r from-purple-400 to-blue-400 bg-clip-text text-transparent">
+      <p className="font-semibold text-md text-black dark:dark:bg-gradient-to-r from-purple-400 to-blue-400 bg-clip-text text-transparent w-56 truncate">
         {name}
       </p>
         <div className="ml-auto flex items-center pl-4">

--- a/components/modals/create-channel-modal.jsx
+++ b/components/modals/create-channel-modal.jsx
@@ -43,6 +43,8 @@ import { useEffect } from "react";
 const formSchema = z.object({
   name: z.string().min(1, {
     message: "Channel name is required.",
+  }).max(25,{
+    message: "Channel name cannot exceed 25 characters."
   }).refine(
     name => name !== "general",
     {

--- a/components/modals/create-server-modal.jsx
+++ b/components/modals/create-server-modal.jsx
@@ -32,6 +32,8 @@ import { useModal } from "@/hooks/use-modal-store";
 const formSchema = z.object({
   name: z.string().min(1, {
     message: "Server name is required.",
+  }).max(60,{
+    message: "Server name cannot exceed 60 characters."
   }),
   imageUrl: z.string().min(1, {
     message: "Server image is required.",

--- a/components/modals/edit-channel-modal.jsx
+++ b/components/modals/edit-channel-modal.jsx
@@ -43,6 +43,8 @@ const formSchema = z.object({
     .string()
     .min(1, {
       message: "Channel name is required.",
+    }).max(25,{
+      message: "Channel name cannot exceed 25 characters."
     })
     .refine((name) => name !== "general", {
       message: "Channel name cannot be 'general'",

--- a/components/modals/edit-server-modal.jsx
+++ b/components/modals/edit-server-modal.jsx
@@ -35,6 +35,8 @@ import { useModal } from "@/hooks/use-modal-store";
 const formSchema = z.object({
   name: z.string().min(1, {
     message: "Server name is required.",
+  }).max(60,{
+    message: "Server name cannot exceed 60 characters."
   }),
   imageUrl: z.string().min(1, {
     message: "Server image is required.",

--- a/components/modals/initial-modal.jsx
+++ b/components/modals/initial-modal.jsx
@@ -32,6 +32,8 @@ import { useRouter } from "next/navigation";
 const formSchema = z.object({
   name: z.string().min(1, {
     message: "Server name is required.",
+  }).max(60,{
+    message: "Server name cannot exceed 60 characters."
   }),
   imageUrl: z.string().min(1, {
     message: "Server image is required.",

--- a/components/server/server-channel.jsx
+++ b/components/server/server-channel.jsx
@@ -42,7 +42,7 @@ export const ServerChannel = ({ channel, server, role }) => {
       <Icon className="flex-shrink-0 w-5 h-5 text-zinc-500 dark:text-[#CBFF01]/80" />
       <p
         className={cn(
-          "line-clamp-1 font-semibold text-sm text-zinc-500 group-hover:text-zinc-600 dark:bg-gradient-to-r from-[#CBFF01] to-[#00FFA3] bg-clip-text text-transparent dark:group-hover:text-[#CBFF01] transition",
+          "truncate font-semibold text-sm text-zinc-500 group-hover:text-zinc-600 dark:bg-gradient-to-r from-[#CBFF01] to-[#00FFA3] bg-clip-text text-transparent dark:group-hover:text-[#CBFF01] transition",
           params?.channelId === channel.id &&
             "dark:bg-gradient-to-r from-[#CBFF01] to-[#00FFA3] bg-clip-text text-transparent dark:group-hover:text-[#CBFF01]"
         )}

--- a/components/server/server-header.jsx
+++ b/components/server/server-header.jsx
@@ -28,12 +28,12 @@ export const ServerHeader = ({ server, role }) => {
     <DropdownMenu>
       <DropdownMenuTrigger className="focus:outline-none" asChild>
         <button
-          className="w-full text-md font-semibold px-3 flex
+          className="truncate w-full text-md font-semibold px-3 flex
                     items-center h-[100px] border-neutral-200
                      hover:bg-zinc-700/10 dark:hover:bg-zinc-700/50 transition dark:bg-gradient-to-r from-blue-600 to-black"
-        >
-          {server.name}
-          <ChevronDown className="h=5 w-5 ml-auto" />
+        > 
+          <p className="truncate w-48">{server.name}</p>
+          <ChevronDown className="h-6 w-6 ml-auto text-blue-500 hover:scale-150" />
         </button>
       </DropdownMenuTrigger>
 

--- a/components/server/server-member.jsx
+++ b/components/server/server-member.jsx
@@ -51,7 +51,7 @@ export const ServerMember = ({
             /> 
             <p
                 className={cn(
-                    "font-semibold text-sm text-zinc-500 group-hover:text-zinc-600 dark:text-[#00FFA3]/70 dark:group-hover:text-zinc-300 transition",
+                    "truncate font-semibold text-sm text-zinc-500 group-hover:text-zinc-600 dark:text-[#00FFA3]/70 dark:group-hover:text-zinc-300 transition",
                     params?.memberId === member.id && "text-primary dark:group-hover:text-white"
                 )}
             >

--- a/components/server/server-sidebar.jsx
+++ b/components/server/server-sidebar.jsx
@@ -136,7 +136,7 @@ export const ServerSidebar = async ({ serverId }) => {
               role={role}
               label="Text Channels"
             />
-            <div className="space-y-[2px]">
+            <div className="w-52 space-y-[2px]">
               {textChannels.map((channel) => (
                 <ServerChannel
                   key={channel.id}
@@ -157,7 +157,7 @@ export const ServerSidebar = async ({ serverId }) => {
               role={role}
               label="Voice Channels"
             />
-            <div className="space-y-[2px]">
+            <div className="w-52 space-y-[2px]">
               {audioChannels.map((channel) => (
                 <ServerChannel
                   key={channel.id}
@@ -177,7 +177,7 @@ export const ServerSidebar = async ({ serverId }) => {
               role={role}
               label="Video Channels"
             />
-            <div className="space-y-[2px]">
+            <div className="w-52 space-y-[2px]">
               {videoChannels.map((channel) => (
                 <ServerChannel
                   key={channel.id}
@@ -197,7 +197,7 @@ export const ServerSidebar = async ({ serverId }) => {
               label="Members"
               server={server}
             />
-            <div className="space-y-[2px]">
+            <div className="w-52 space-y-[2px]">
               {members.map((member) => (
                 <ServerMember 
                   key={member.id}


### PR DESCRIPTION
**Description**
This PR fixes #22 by fixing the width of the server name and channel name containers and truncating the overflowing text.

**Related Issues**
 Fixes #22 

**Type of Change**

* Check one or more boxes that apply:
    - [X] Bug fix
    
**Changes Made:**
 - Set the width of divs containing the channels and members to w-52. (In file **'components\server\server-sidebar.jsx'**).
 - Added **truncate** property to `<p>{channel.name}</p>` to prevent channel names from overflowing the container. (In file **'components\server\server-channel.jsx'**
 - Converted the 'server.name' to a `<p>{server.name}</p>` tag and added the **truncate** property to prevent the server name from overflowing its button container. (In file **'components\server\server-header.jsx'**).
 -  Added **truncate** property to `<p>{member.profile.name}</p>` to prevent member names from overflowing the container. (In file **'components\server\server-member.jsx'**).
 - Added **w-56** and **truncate** to`<p>{name}</p>` in **'chat-header.jsx'**.
 - Added max limit of 25 characters to channel name in form schema. (In **create-channel-modal.jsx** and **edit-channel-modal.jsx**).

**Screenshots or Screen Recording (if applicable):**
![image](https://github.com/Univibe-majorproject/UniVibe/assets/65300982/f71c2916-e7aa-451d-a214-aa0445046df1)


