### PR TITLE
Fix : Issue #47 Error on trying to join a server using old/invalid invite url

### DIFF
--- a/app/(invite)/(routes)/invite/[inviteCode]/page.js
+++ b/app/(invite)/(routes)/invite/[inviteCode]/page.js
@@ -17,6 +17,21 @@ const InviteCodePage = async ({ params }) => {
     return redirect("/");
   }
 
+  //checking if any server exists with the invite code
+  const serverWithInviteCode = await db.server.findFirst({
+    where:{
+      inviteCode: params.inviteCode,
+    }
+  })
+
+  if(!serverWithInviteCode){
+    return (
+      <p className="font-bold text-2xl text-red-500 flex items-center justify-center mt-8">
+        Error! Invalid or old invite url.
+      </p>
+    )
+  }
+
   //to check if the user is already a part of this server
   const existingServer = await db.server.findFirst({
     where: {


### PR DESCRIPTION
**Description**
This PR adds a custom error message for the runtime error that occurs when a person tries to join a server with an invalid or old invite url.

**Related Issues**
Fixes #47 

**Type of Change**

* Check one or more boxes that apply:
    - [X] Bug fix

**Changes Made:**
- In file (**'app\\(invite)\\(routes)\invite\\[inviteCode]\\page.js'**)
- Added a **check** for checking if a server exists in the database with the specified invite code in the invite url. 
- If no server exists in the database with the given invite code (from params in the invite url) then a **custom error message** is displayed on the screen stating that the invite url is invalid or old.

**Screenshots or Screen Recording (if applicable):**
![image](https://github.com/Univibe-majorproject/UniVibe/assets/65300982/3e4f6174-7d64-44c2-aa93-0005262e2c4a)


**Additional Information**
- For now i have added a custom error message for this error but we should also checkout custom error pages. (just for more information)
