### PR TITLE
Fix: 'general' named channels cannot be created in any alphabetical case

### DIFF
--- a/app/(main)/(routes)/servers/[serverId]/page.js
+++ b/app/(main)/(routes)/servers/[serverId]/page.js
@@ -22,6 +22,7 @@ const ServerIdPage = async ({ params }) => {
       channels: {
         where: {
           name: "general",
+          type: "TEXT",
         },
         orderBy: {
           createdAt: "asc",

--- a/app/api/servers/route.js
+++ b/app/api/servers/route.js
@@ -20,7 +20,11 @@ export async function POST(req) {
         imageUrl,
         inviteCode: uuidv4(),
         channels: {
-          create: [{ name: "general", profileId: profile.id }],
+          create: [
+            { name: "general", profileId: profile.id },
+            { name: "general", type: "AUDIO", profileId: profile.id },
+            { name: "general", type: "VIDEO", profileId: profile.id },
+          ],
         },
         members: {
           create: [{ profileId: profile.id, role: MemberRole.ADMIN }],

--- a/components/modals/create-channel-modal.jsx
+++ b/components/modals/create-channel-modal.jsx
@@ -46,7 +46,7 @@ const formSchema = z.object({
   }).max(25,{
     message: "Channel name cannot exceed 25 characters."
   }).refine(
-    name => name.toLowerCase() !== "general",
+    name => name.toLowerCase().trim() !== "general",
     {
       message: "Channel name cannot be 'general'"
     }

--- a/components/modals/create-channel-modal.jsx
+++ b/components/modals/create-channel-modal.jsx
@@ -46,7 +46,7 @@ const formSchema = z.object({
   }).max(25,{
     message: "Channel name cannot exceed 25 characters."
   }).refine(
-    name => name !== "general",
+    name => name.toLowerCase() !== "general",
     {
       message: "Channel name cannot be 'general'"
     }

--- a/components/modals/edit-channel-modal.jsx
+++ b/components/modals/edit-channel-modal.jsx
@@ -47,7 +47,7 @@ const formSchema = z.object({
       message: "Channel name cannot exceed 25 characters."
     })
     .refine(
-      (name) => name.toLowerCase() !== "general", {
+      (name) => name.toLowerCase().trim() !== "general", {
       message: "Channel name cannot be 'general'",
     }),
 

--- a/components/modals/edit-channel-modal.jsx
+++ b/components/modals/edit-channel-modal.jsx
@@ -46,7 +46,8 @@ const formSchema = z.object({
     }).max(25,{
       message: "Channel name cannot exceed 25 characters."
     })
-    .refine((name) => name !== "general", {
+    .refine(
+      (name) => name.toLowerCase() !== "general", {
       message: "Channel name cannot be 'general'",
     }),
 

--- a/components/server/server-member.jsx
+++ b/components/server/server-member.jsx
@@ -18,8 +18,8 @@ import { UserAvatar } from "@/components/user-avatar";
 
 const roleIconMap = {
     [MemberRole.GUEST]: null,
-    [MemberRole.MODERATOR]: <ShieldCheck className="h-4 w-4 ml-2 text-indigo-500"/>,
-    [MemberRole.ADMIN]: <ShieldAlert className="h-4 w-4 ml-2 text-rose-500"/>,
+    [MemberRole.MODERATOR]: <ShieldCheck className="h-4 w-4 ml-1 text-indigo-500"/>,
+    [MemberRole.ADMIN]: <ShieldAlert className="h-4 w-4 ml-1 text-rose-500"/>,
 
 }
 
@@ -51,7 +51,7 @@ export const ServerMember = ({
             /> 
             <p
                 className={cn(
-                    "truncate font-semibold text-sm text-zinc-500 group-hover:text-zinc-600 dark:text-[#00FFA3]/70 dark:group-hover:text-zinc-300 transition",
+                    "truncate font-semibold text-sm text-zinc-500 group-hover:text-zinc-600 dark:text-[#00FFA3]/70 dark:group-hover:text-zinc-300 transition w-32",
                     params?.memberId === member.id && "text-primary dark:group-hover:text-white"
                 )}
             >


### PR DESCRIPTION
**Description**

This PR fixes the problem that 'general' or 'GENERAL' etc named channels can be created by changing the case of some letters in spelling 'General' and those channels still follow the property of default 'general' channel.

Also, added default AUDIO and VIDEO 'general' channels for every server that is created. 

**Related Issues**

Fixes #52 

**Type of Change**

* Check one or more boxes that apply:
    - [X] Bug fix

**Changes Made:**
- added `toLowerCase()` property to channel **name** in the form schema of **'create-channel-modal.jsx'** and **'edit-channel-modal.jsx'** to prevent the creation or name editing to 'general' channel in any alphabetical case. 
-  added code for default 'general' AUDIO and VIDEO channels creation on server creation for every server. (in file -> **'app\api\servers\route.js'**)


**Screenshots or Screen Recording (if applicable):**
*Default general Audio and Video channels :*
![image](https://github.com/Univibe-majorproject/UniVibe/assets/65300982/e6e73c4f-1694-49d4-8d1f-ebf79407efbd)

*Preventing the creation or name edit of channels to 'general' in any alphabetical case*
![image](https://github.com/Univibe-majorproject/UniVibe/assets/65300982/0e66ddc8-f76f-4df5-b4bd-5552c79be4fe)

![image](https://github.com/Univibe-majorproject/UniVibe/assets/65300982/f0bc3800-271e-4862-98f8-63b60d52e510)
